### PR TITLE
Allow usage of existing BiG-SCAPE results directory in BiG-MAP.family.py

### DIFF
--- a/src/BiG-MAP.family.py
+++ b/src/BiG-MAP.family.py
@@ -1123,6 +1123,8 @@ concerning the input files of this module.")
         # Run second redundancy filtering
         ###################################
         if args.bigscape_results != None:
+            if not os.path.isdir(args.bigscape_results):
+                raise RuntimeError('BiG-SCAPE results directory provided by user does not exist!')
             parsed = {}
             print("___Retrieving Existing BiG-SCAPE Results___")
             for tsv_file in retrieve_existing_bigscapefiles(args.bigscape_results):
@@ -1232,6 +1234,8 @@ For example: s1....region001.gbk is not allowed, s1..region001.gbk is accepted")
         # Run second redundancy filtering
         ###################################
         if args.bigscape_results != None:
+            if not os.path.isdir(args.bigscape_results):
+                raise RuntimeError('BiG-SCAPE results directory provided by user does not exist!')
             parsed = {}
             print("___Retrieving Existing BiG-SCAPE Results___")
             for tsv_file in retrieve_existing_bigscapefiles(args.bigscape_results):

--- a/src/BiG-MAP.family.py
+++ b/src/BiG-MAP.family.py
@@ -1262,7 +1262,7 @@ For example: s1....region001.gbk is not allowed, s1..region001.gbk is accepted")
         #############################
         # Pickling
         #############################
-        if args.bigscape_path:
+        if args.bigscape_path or args.bigscape_results != None:
             pickle_files(fastadict_ALL, fasta_file, bed_file, args.outdir, dict_json)
         else:
             pickle_files(fastadict_ALL, fasta_file, bed_file, args.outdir)

--- a/src/BiG-MAP.family.py
+++ b/src/BiG-MAP.family.py
@@ -1125,7 +1125,7 @@ concerning the input files of this module.")
         if args.bigscape_results != None:
             parsed = {}
             print("___Retrieving Existing BiG-SCAPE Results___")
-            for tsv_file in retrieve_existing_bigscapefiles(args.outdir):
+            for tsv_file in retrieve_existing_bigscapefiles(args.bigscape_results):
                 parsed.update(parse_bigscape_result(tsv_file))
 
             dict_json = make_jsondict(parsed, fastadict)
@@ -1234,7 +1234,7 @@ For example: s1....region001.gbk is not allowed, s1..region001.gbk is accepted")
         if args.bigscape_results != None:
             parsed = {}
             print("___Retrieving Existing BiG-SCAPE Results___")
-            for tsv_file in retrieve_existing_bigscapefiles(args.outdir):
+            for tsv_file in retrieve_existing_bigscapefiles(args.bigscape_results):
                 parsed.update(parse_bigscape_result(tsv_file))
 
             dict_json = make_jsondict(parsed, fastadict_ALL)


### PR DESCRIPTION
Hi, BiG-MAP is awesome, thank you for developing it and the clear documentation! 

I made a small set of changes to `BiG-MAP.family.py` to allow it to take in as input an existing BiG-SCAPE results directory in case users want to run it with customized parameters and outside of `BiG-MAP.family.py` as we did. Also, if there is a specific reason to avoid using existing BiG-SCAPE results, please let me know!

Kind regards,
Rauf